### PR TITLE
Fix header position and add text-shadow for readability

### DIFF
--- a/src/assets/scss/components/navbar.scss
+++ b/src/assets/scss/components/navbar.scss
@@ -21,6 +21,7 @@ header {
   padding: 0.5rem 0.5rem;
   font-weight: 600;
   font-size: 15px;
+  text-shadow: 0px 0px 6px #e54c2e;
 }
 
 .shifting, .nav-links:hover {

--- a/src/assets/scss/sections/competitionChild.scss
+++ b/src/assets/scss/sections/competitionChild.scss
@@ -3,4 +3,6 @@
 .program {
   display: block;
   height: 200px;
+  position: relative;
+  z-index: -1;
 }


### PR DESCRIPTION
I fixed the position of the header links over all other elements. Also, I added a text-shadow to match the First Steps logo and maintain readability when it's positioned over white elements. Let me know if you'd like to see any other change here! 

<img width="1440" alt="Screen Shot 2020-10-24 at 11 24 06 AM" src="https://user-images.githubusercontent.com/14588617/97086937-04af6200-15ec-11eb-8a01-5668648f21f9.png">
<img width="1438" alt="Screen Shot 2020-10-24 at 11 24 53 AM" src="https://user-images.githubusercontent.com/14588617/97086938-0711bc00-15ec-11eb-9a79-5fdf5672598f.png">

Closes #3 
